### PR TITLE
Backward Compatible Support for network >= 2.6

### DIFF
--- a/iCalendar.cabal
+++ b/iCalendar.cabal
@@ -1,5 +1,5 @@
 name:                iCalendar
-version:             0.4.0.2
+version:             0.4.0.1
 synopsis:            iCalendar data types, parser, and printer.
 description:         Data definitions, parsing and printing of the iCalendar
                      format (RFC5545).
@@ -21,7 +21,7 @@ source-repository head
   location:          git://github.com/tingtun/iCalendar.git
 flag network-uri
    description: Get Network.URI from the network-uri package
-   default: False
+   default: True
 
 library
   exposed-modules:     Text.ICalendar.Types


### PR DESCRIPTION
Hi there,

this should give us backward compatible support for network >= 2.6, which means client of network < 2.6 shouldn't be affected.
I was able to test this only in a nix-shell and in a cabal sandbox, but it does seem to work.
Someones willing to test?

I have also bumped the manifest version.
