### PR TITLE
Updates to fix for GHC 7.10. Depends on unreleased, updated 'mime'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.swp
+*~
 dist/
 shell.nix
+.cabal-sandbox
+cabal.sandbox.config

--- a/Text/ICalendar/Parser/Content.hs
+++ b/Text/ICalendar/Parser/Content.hs
@@ -75,7 +75,7 @@ char c = scan True f <?> show c
 
 isControl', isSafe, isValue, isQSafe, isName :: Char -> Bool
 isControl' c = c /= '\t' && isControl c
-isSafe c = not (isControl' c) && c `notElem` "\";:,"
+isSafe c = not (isControl' c) && c `notElem` ("\";:,"::String)
 isValue c = let n = fromEnum c in n == 32 || n == 9 || (n >= 0x21 && n /= 0x7F)
 isQSafe c = isValue c && c /= '"'
 isName c = isAsciiUpper c || isAsciiLower c || isDigit c || c == '-'

--- a/Text/ICalendar/Parser/Parameters.hs
+++ b/Text/ICalendar/Parser/Parameters.hs
@@ -193,7 +193,7 @@ parseUTCPeriod bs = do
     when (B.null x) . throwError $ "Invalid UTCperiod: " ++ show bs
     dateTime <- mustBeUTC =<< parseDateTime Nothing dateTime'
     case B.head x of
-         z | z `elem` "+-P" -> UTCPeriodDuration dateTime
+         z | z `elem` ("+-P"::String) -> UTCPeriodDuration dateTime
                                     <$> parseDuration "period" x
          _ -> UTCPeriodDates dateTime <$> (mustBeUTC =<< parseDateTime Nothing x)
 
@@ -203,6 +203,6 @@ parsePeriod tzid bs = do
     when (B.null x) . throwError $ "Invalid period: " ++ show bs
     dateTime <- parseDateTime tzid dateTime'
     case B.head x of
-         z | z `elem` "+-P" -> PeriodDuration dateTime
+         z | z `elem` ("+-P"::String) -> PeriodDuration dateTime
                                     <$> parseDuration "period" x
          _ -> PeriodDates dateTime <$> parseDateTime tzid x

--- a/Text/ICalendar/Parser/Properties.hs
+++ b/Text/ICalendar/Parser/Properties.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TupleSections     #-}
+{-# LANGUAGE FlexibleContexts  #-}
 module Text.ICalendar.Parser.Properties where
 
 import           Control.Applicative
@@ -379,7 +380,7 @@ parseUTCOffset (ContentLine _ n o bs)
         (t1:t2:m1:m2:sec) = map digitToInt rest
         (s1:s2:_) = sec
         sign x = if s == '-' then negate x else x
-    when (length str < 5 || any (not . isDigit) rest || s `notElem` "+-"
+    when (length str < 5 || any (not . isDigit) rest || s `notElem` ['+','-']
                          || length sec `notElem` [0,2]) .
         throwError $ "parseUTCOffset: " ++ str
     return . UTCOffset (sign $ ((t1 * 10 + t2) * 60 + (m1 * 10 + m2)) * 60 +

--- a/Text/ICalendar/Printer.hs
+++ b/Text/ICalendar/Printer.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TupleSections     #-}
+{-# LANGUAGE CPP #-}
 module Text.ICalendar.Printer
     ( EncodingFunctions(..)
     , printICalendar
@@ -32,7 +33,13 @@ import qualified Data.Time                    as Time
 import qualified Data.Version                 as Ver
 import qualified Network.URI                  as URI
 import           Prelude                      hiding (mapM_)
-import qualified System.Locale                as L
+
+#if MIN_VERSION_time(1,5,0)
+import Data.Time (defaultTimeLocale)
+#else
+import System.Locale (defaultTimeLocale)
+#endif
+
 import           Text.Printf                  (printf)
 
 import           Codec.MIME.Type             (MIMEType, showMIMEType)
@@ -967,6 +974,6 @@ line :: ByteString -> ContentPrinter ()
 line b = tell (Bu.lazyByteString b) >> newline
 
 formatTime :: FormatTime t => String -> t -> String
-formatTime = Time.formatTime L.defaultTimeLocale
+formatTime = Time.formatTime defaultTimeLocale
 
 -- }}}

--- a/iCalendar.cabal
+++ b/iCalendar.cabal
@@ -1,5 +1,5 @@
 name:                iCalendar
-version:             0.4.0.2
+version:             0.4.0.3
 synopsis:            iCalendar data types, parser, and printer.
 description:         Data definitions, parsing and printing of the iCalendar
                      format (RFC5545).
@@ -40,9 +40,9 @@ library
   else
     build-depends: network >= 2.4 && < 2.6
 
-  build-depends:       base >=4.5 && <5, time ==1.4.*, data-default >=0.3
+  build-depends:       base >=4.5 && <5, time >=1.4, data-default >=0.3
                      , case-insensitive >=0.4
                      , bytestring >=0.10 && < 0.11, parsec >=3.1.0
-                     , text, containers >= 0.5 && < 0.6, mime ==0.4.*
+                     , text, containers >= 0.5 && < 0.6, mime >=0.4.0.2
                      , mtl >=2.1.0, old-locale, base64-bytestring ==1.0.*
   ghc-options:       -Wall


### PR DESCRIPTION
Hi there - this is a first stab at fixing iCalendar to build with GHC 7.10. I had to patch 'mime', and bumped the version thereof to '0.4.0.2' (pull request sent to author, but as-yet unpublished - build locally from my fork in meantime). I also updated the minor version of iCalendar - so that my own project(s) can distinguish, I hope that's OK.

Thanks for a fabulous library - so useful!