### PR TITLE
iCalendar.cabal: add missing Paths_iCalendar module

### DIFF
--- a/iCalendar.cabal
+++ b/iCalendar.cabal
@@ -34,6 +34,7 @@ library
                      , Text.ICalendar.Parser.Content
                      , Text.ICalendar.Parser.Parameters
                      , Text.ICalendar.Parser.Properties
+                     , Paths_iCalendar
 
   if flag(network-uri)
     build-depends: network-uri >= 2.6, network >= 2.6 && < 2.7


### PR DESCRIPTION
Noticed as a quickfuzz build breakage (http://quickfuzz.org/):
  can't load .so/.DLL for: .../libHSiCalendar-0.4.0.4-2VZGCUKX8TfFH3xdw7yYla-ghc8.0.2.so
    (.../libHSiCalendar-0.4.0.4-2VZGCUKX8TfFH3xdw7yYla-ghc8.0.2.so: undefined symbol:
    iCalendarzm0zi4zi0zi4zm2VZZGCUKX8TfFH3xdw7yYla_PathszuiCalendar_version1_closure)

It's a symbol iCalendar-0.4.0.4-2VZGCUKX8TfFH3xdw7yYla_Paths_iCalendar_version1_closure

This change adds missing module into other-modules.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>