### PR TITLE
Delete weird module export

### DIFF
--- a/Text/ICalendar/Types.hs
+++ b/Text/ICalendar/Types.hs
@@ -3,8 +3,7 @@
 {-# LANGUAGE OverloadedStrings  #-}
 -- | ICalendar types, based on RFC5545.
 module Text.ICalendar.Types
-    ( module Text.ICalendar.Types
-    ) where
+     where
 
 import           Codec.MIME.Type            (MIMEType)
 import           Data.ByteString.Lazy.Char8 (ByteString)
@@ -12,15 +11,15 @@ import           Data.CaseInsensitive       (CI)
 import           Data.Default
 import           Data.Map                   (Map)
 import qualified Data.Map                   as M
-import           Data.Set                   (Set)
 import           Data.Semigroup             as Sem
+import           Data.Set                   (Set)
 import           Data.Text.Lazy             (Text, pack)
 import           Data.Time
 import           Data.Typeable              (Typeable)
 import           Data.Version               (Version (..), showVersion)
 import           Network.URI                (URI)
 
-import Paths_iCalendar (version)
+import           Paths_iCalendar            (version)
 
 -- | Language.
 newtype Language = Language (CI Text) -- TODO: RFC5646 types and parser.


### PR DESCRIPTION
I had a weird linking issue:

```
Linking /home/jappie/projects/raster/dist-newstyle/build/x86_64-linux/ghc-8.4.3/backend-1.0.0.0/x/webservice/build/webservice/webservice ...
/nix/store/qf5gpsni5bdj7lmgbglwgpa50ggk4hxf-iCalendar-0.4.0.4/lib/ghc-8.4.3/x86_64-linux-ghc-8.4.3/iCalendar-0.4.0.4-5r3g51XSsMd8U47yPc2qBJ/libHSiCalendar-0.4.0.4-5r3g51XSsMd8U47yPc2qBJ.a(Types.o):(.text.iCalendarzm0zi4zi0zi4zm5r3g51XSsMd8U47yPc2qBJ_TextziICalendarziTypes_zdfDefaultVCalendar7_info+0x28f): undefined reference to `iCalendarzm0zi4zi0zi4zm5r3g51XSsMd8U47yPc2qBJ_PathszuiCalendar_version1_closure'
collect2: error: ld returned 1 exit status
`cc' failed in phase `Linker'. (Exit code: 1)
cabal: Failed to build exe:webservice from backend-1.0.0.0.

make: *** [makefile:30: build] Error 1

```

After changing the types module export to not refer to itself it worked again.