### PR TITLE
Loosen upper bounds to build with newer versions

### DIFF
--- a/iCalendar.cabal
+++ b/iCalendar.cabal
@@ -37,9 +37,9 @@ library
                      , Paths_iCalendar
 
   if flag(network-uri)
-    build-depends: network-uri >= 2.6, network >= 2.6 && < 2.9
+    build-depends: network-uri >= 2.6, network >= 2.6 && < 3.2
   else
-    build-depends: network >= 2.4 && < 2.9
+    build-depends: network >= 2.4 && < 3.2
 
   if !impl(ghc >= 8.0)
     build-depends: semigroups == 0.18.*


### PR DESCRIPTION
I bumped some bounds on dependencies, to make it build with newer versions.
