### PR TITLE
Make iCalendar build with latest versions of deps

### DIFF
--- a/Text/ICalendar/Parser/Common.hs
+++ b/Text/ICalendar/Parser/Common.hs
@@ -9,7 +9,7 @@ import           Control.Monad.Error          hiding (mapM)
 import           Control.Monad.RWS            (MonadState (get, put),
                                                MonadWriter (tell), RWS, asks,
                                                modify)
-import qualified Data.ByteString.Lazy.Builder as Bu
+import qualified Data.ByteString.Builder      as Bu
 import           Data.ByteString.Lazy.Char8   (ByteString)
 import qualified Data.ByteString.Lazy.Char8   as B
 import           Data.CaseInsensitive         (CI)

--- a/Text/ICalendar/Parser/Content.hs
+++ b/Text/ICalendar/Parser/Content.hs
@@ -4,7 +4,7 @@ module Text.ICalendar.Parser.Content where
 import           Control.Applicative
 import           Control.Monad
 import           Data.ByteString.Lazy         (ByteString)
-import qualified Data.ByteString.Lazy.Builder as Bu
+import qualified Data.ByteString.Builder      as Bu
 import           Data.CaseInsensitive         (CI)
 import           Data.Char
 import           Data.Monoid

--- a/Text/ICalendar/Printer.hs
+++ b/Text/ICalendar/Printer.hs
@@ -16,8 +16,8 @@ import           Control.Monad.RWS            (MonadState (get, put),
                                                MonadWriter (tell), RWS, asks,
                                                modify, runRWS)
 import           Data.ByteString.Lazy         (ByteString)
-import           Data.ByteString.Lazy.Builder (Builder)
-import qualified Data.ByteString.Lazy.Builder as Bu
+import           Data.ByteString.Builder      (Builder)
+import qualified Data.ByteString.Builder      as Bu
 import qualified Data.ByteString.Lazy.Char8   as BS
 import qualified Data.CaseInsensitive         as CI
 import           Data.Char                    (ord, toUpper)

--- a/iCalendar.cabal
+++ b/iCalendar.cabal
@@ -37,16 +37,16 @@ library
                      , Paths_iCalendar
 
   if flag(network-uri)
-    build-depends: network-uri >= 2.6, network >= 2.6 && < 2.9
+    build-depends: network-uri >= 2.6, network >= 2.6 && < 3.2
   else
-    build-depends: network >= 2.4 && < 2.9
+    build-depends: network >= 2.4 && < 3.2
 
   if !impl(ghc >= 8.0)
     build-depends: semigroups == 0.18.*
 
   build-depends:       base >=4.5 && <5, time >=1.5, data-default >=0.3
                      , case-insensitive >=0.4
-                     , bytestring >=0.10 && < 0.11, parsec >=3.1.0
+                     , bytestring >=0.10 && < 0.12, parsec >=3.1.0
                      , text, containers >= 0.5 && < 0.7, mime >=0.4.0.2
-                     , mtl >=2.1.0, old-locale, base64-bytestring ==1.0.*
+                     , mtl >=2.1.0, old-locale, base64-bytestring >=1.0 && <1.3
   ghc-options:       -Wall


### PR DESCRIPTION
...and consequently GHC 9.2.x. Mostly this was just a matter of relaxing
version bounds, but the import paths for bytestring Builders needed
adjusting as well.