### PR TITLE
Update to bytestring-0.11 and mtl-2.3.1

### DIFF
--- a/Text/ICalendar/Parser.hs
+++ b/Text/ICalendar/Parser.hs
@@ -12,7 +12,7 @@ module Text.ICalendar.Parser
 
 import           Control.Applicative
 import           Control.Monad
-import           Control.Monad.Error
+import           Control.Monad.Except
 import           Control.Monad.RWS          (runRWS)
 import           Data.ByteString.Lazy       (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as B
@@ -70,4 +70,4 @@ parseICalFile = parseICalendarFile
 
 runCP :: DecodingFunctions -> ContentParser a
       -> (Either String a, (SourcePos, [Content]), [String])
-runCP s = ((flip .) . flip) runRWS s (undefined, undefined) . runErrorT
+runCP s = ((flip .) . flip) runRWS s (undefined, undefined) . runExceptT

--- a/Text/ICalendar/Parser/Common.hs
+++ b/Text/ICalendar/Parser/Common.hs
@@ -9,7 +9,7 @@ import           Control.Monad.Error          hiding (mapM)
 import           Control.Monad.RWS            (MonadState (get, put),
                                                MonadWriter (tell), RWS, asks,
                                                modify)
-import qualified Data.ByteString.Lazy.Builder as Bu
+import qualified Data.ByteString.Builder      as Bu
 import           Data.ByteString.Lazy.Char8   (ByteString)
 import qualified Data.ByteString.Lazy.Char8   as B
 import           Data.CaseInsensitive         (CI)

--- a/Text/ICalendar/Parser/Common.hs
+++ b/Text/ICalendar/Parser/Common.hs
@@ -5,7 +5,8 @@ module Text.ICalendar.Parser.Common where
 
 import           Control.Applicative
 import           Control.Arrow                (second)
-import           Control.Monad.Error          hiding (mapM)
+import           Control.Monad                (when, unless, (<=<))
+import           Control.Monad.Except         hiding (mapM)
 import           Control.Monad.RWS            (MonadState (get, put),
                                                MonadWriter (tell), RWS, asks,
                                                modify)
@@ -50,7 +51,7 @@ data Content = ContentLine P.SourcePos (CI Text) [(CI Text, [Text])] ByteString
 
 type TextParser = P.Parsec ByteString DecodingFunctions
 
-type ContentParser = ErrorT String -- Fatal errors.
+type ContentParser = ExceptT String -- Fatal errors.
                             (RWS DecodingFunctions
                                  [String] -- Warnings.
                                  (P.SourcePos, [Content]))

--- a/Text/ICalendar/Parser/Components.hs
+++ b/Text/ICalendar/Parser/Components.hs
@@ -5,7 +5,8 @@ module Text.ICalendar.Parser.Components where
 
 import           Control.Applicative
 import           Control.Arrow        ((&&&))
-import           Control.Monad.Error  hiding (mapM)
+import           Control.Monad        (when)
+import           Control.Monad.Except hiding (mapM)
 import           Control.Monad.RWS    (MonadState (get), tell)
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Foldable        as F

--- a/Text/ICalendar/Parser/Content.hs
+++ b/Text/ICalendar/Parser/Content.hs
@@ -4,7 +4,7 @@ module Text.ICalendar.Parser.Content where
 import           Control.Applicative
 import           Control.Monad
 import           Data.ByteString.Lazy         (ByteString)
-import qualified Data.ByteString.Lazy.Builder as Bu
+import qualified Data.ByteString.Builder      as Bu
 import           Data.CaseInsensitive         (CI)
 import           Data.Char
 import           Data.Monoid

--- a/Text/ICalendar/Parser/Parameters.hs
+++ b/Text/ICalendar/Parser/Parameters.hs
@@ -2,7 +2,8 @@
 module Text.ICalendar.Parser.Parameters where
 
 import           Control.Applicative
-import           Control.Monad.Error
+import           Control.Monad              (void, when)
+import           Control.Monad.Except
 import           Control.Monad.RWS          (MonadWriter (tell))
 import           Data.ByteString.Lazy.Char8 (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as B

--- a/Text/ICalendar/Parser/Properties.hs
+++ b/Text/ICalendar/Parser/Properties.hs
@@ -5,7 +5,8 @@
 module Text.ICalendar.Parser.Properties where
 
 import           Control.Applicative
-import           Control.Monad.Error          hiding (mapM)
+import           Control.Monad                (when, (<=<))
+import           Control.Monad.Except         hiding (mapM)
 import           Control.Monad.RWS            (asks)
 import qualified Data.ByteString.Base64.Lazy  as B64
 import qualified Data.ByteString.Lazy.Char8   as B

--- a/Text/ICalendar/Printer.hs
+++ b/Text/ICalendar/Printer.hs
@@ -16,8 +16,8 @@ import           Control.Monad.RWS            (MonadState (get, put),
                                                MonadWriter (tell), RWS, asks,
                                                modify, runRWS)
 import           Data.ByteString.Lazy         (ByteString)
-import           Data.ByteString.Lazy.Builder (Builder)
-import qualified Data.ByteString.Lazy.Builder as Bu
+import           Data.ByteString.Builder      (Builder)
+import qualified Data.ByteString.Builder      as Bu
 import qualified Data.ByteString.Lazy.Char8   as BS
 import qualified Data.CaseInsensitive         as CI
 import           Data.Char                    (ord, toUpper)

--- a/iCalendar.cabal
+++ b/iCalendar.cabal
@@ -37,16 +37,16 @@ library
                      , Paths_iCalendar
 
   if flag(network-uri)
-    build-depends: network-uri >= 2.6, network >= 2.6 && < 2.9
+    build-depends: network-uri >= 2.6, network >= 2.6
   else
-    build-depends: network >= 2.4 && < 2.9
+    build-depends: network >= 2.4
 
   if !impl(ghc >= 8.0)
     build-depends: semigroups == 0.18.*
 
   build-depends:       base >=4.5 && <5, time >=1.5, data-default >=0.3
                      , case-insensitive >=0.4
-                     , bytestring >=0.10 && < 0.11, parsec >=3.1.0
+                     , bytestring >=0.11 && <1.0.0, parsec >=3.1.0
                      , text, containers >= 0.5 && < 0.7, mime >=0.4.0.2
-                     , mtl >=2.1.0, old-locale, base64-bytestring ==1.0.*
+                     , mtl >=2.1.0, old-locale, base64-bytestring >=1.0.0
   ghc-options:       -Wall


### PR DESCRIPTION
Hi @chrra,

to get this package to compile in my project (using stack) I needed to make it compatible with a newer version of bytestring. I also had to remove an upper boundary on network.

Can you merge and publish it on hackage?

------

Since [mtl](https://hackage.haskell.org/package/mtl) had a breaking change from 2.2 to 2.3, iCalendar again won't compile.

I quickly fixed it and updated [branch master on my fork](https://github.com/schoettl/iCalendar/). You can use my fork e.g. with stack by putting this into your `stack.yaml`.

```yaml
…

extra-deps:
- git: https://github.com/schoettl/iCalendar.git
  commit: 9c596c859720c349aa8860499030decf1666d6de
  # use the latest commit

```

Tested with stack lts-22.26 and GHC 9.6.